### PR TITLE
Animate scroll view inset changes along with keyboard animation

### DIFF
--- a/EKKeyboardAvoiding/EKKeyboardAvoidingProvider.m
+++ b/EKKeyboardAvoiding/EKKeyboardAvoidingProvider.m
@@ -90,8 +90,11 @@ static NSString *const kKeyboardFrameKey = @"keyboardFrame";
 
 - (void)applyAvoidingContentInset:(UIEdgeInsets)avoidingInset
 {
-    [[self scrollView] setContentInset:avoidingInset];
-    [[self scrollView] setScrollIndicatorInsets:avoidingInset];
+    NSTimeInterval animationDuration = [self.keyboardListener.keyboardInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue];
+    [UIView animateWithDuration:animationDuration animations:^{
+        [[self scrollView] setContentInset:avoidingInset];
+        [[self scrollView] setScrollIndicatorInsets:avoidingInset];
+    }];
 }
 
 - (UIEdgeInsets)calculateExtraContentInset

--- a/EKKeyboardAvoiding/EKKeyboardFrameListener.h
+++ b/EKKeyboardAvoiding/EKKeyboardFrameListener.h
@@ -20,4 +20,7 @@
 /// Last observed keyboard frame
 @property (nonatomic,readonly) CGRect keyboardFrame;
 
+/// Last observed keyboard change info
+@property (nonatomic,strong,readonly) NSDictionary *keyboardInfo;
+
 @end

--- a/EKKeyboardAvoiding/EKKeyboardFrameListener.m
+++ b/EKKeyboardAvoiding/EKKeyboardFrameListener.m
@@ -44,7 +44,7 @@
 
 - (void)startNotificationsObseving
 {
-    [self observeNotificationNamed:UIKeyboardDidChangeFrameNotification
+    [self observeNotificationNamed:UIKeyboardWillChangeFrameNotification
                             action:@selector(keyboardDidChangeFrame:)];
 }
 


### PR DESCRIPTION
This will animate `UIScrollView` inset changes instead of just setting it immediately when keyboard appears or disappears on screen. Additionally, the `UIKeyboardWillChangeFrameNotification` will be observed instead of `UIKeyboardDidChangeFrameNotification` to process the animation together with keyboard animation and not after it completes.
